### PR TITLE
Ver1.0.1の対応完了

### DIFF
--- a/Assets/SocialWorker/Editor.meta
+++ b/Assets/SocialWorker/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 72c19739a2bb7884b972758762fda352
+folderAsset: yes
+timeCreated: 1448863217
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SocialWorker/Editor/SocialWorkerPostProcessBuild.cs
+++ b/Assets/SocialWorker/Editor/SocialWorkerPostProcessBuild.cs
@@ -1,0 +1,29 @@
+﻿using UnityEngine;
+using UnityEditor;
+using UnityEditor.Callbacks;
+using System;
+using System.IO;
+using System.Text;
+
+public static class SocialWorkerPostProcessBuild
+{
+	[PostProcessBuild(1)]
+    public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
+	{
+		if(target != BuildTarget.iOS) { return; }
+
+        string path = Path.Combine(pathToBuiltProject, "Info.plist");
+		string text = File.ReadAllText (path, Encoding.UTF8).Replace (
+			"  </dict>\n" +
+			"</plist>", 
+
+			"    <key>LSApplicationQueriesSchemes</key>\n" +
+			"    <array>\n" +
+			"      <string>line</string>\n" +
+			"      <string>instagram</string>\n" +
+			"    </array>\n" +
+			"  </dict>\n" +
+			"</plist>");
+		File.WriteAllText (path, text, Encoding.UTF8);
+	}
+}

--- a/Assets/SocialWorker/Editor/SocialWorkerPostProcessBuild.cs.meta
+++ b/Assets/SocialWorker/Editor/SocialWorkerPostProcessBuild.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3a86086a519884f16a2164c044e53114
+timeCreated: 1448630435
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SocialWorker/readme_en.txt
+++ b/Assets/SocialWorker/readme_en.txt
@@ -29,5 +29,9 @@ Post of message and image is supported.
 (2)[SocialWorker.PostTwitter][SocialWorker.PostFacebook][SocialWorker.PostLine][SocialWorker.PostInstagram][SocialWorker.PostMail][SocialWorker.CreateChooser] is called.
 
 ■Version History
-▽1.0.0
-First release
+
+1.0.1
+- add : [Editor/SocialWorkerPostProcessBuild]. Custom URL Scheme has to be written in info.plist in iOS9, modify of the bug URL doesn't open.
+
+1.0.0
+- First release

--- a/Assets/SocialWorker/readme_jp.txt
+++ b/Assets/SocialWorker/readme_jp.txt
@@ -29,5 +29,9 @@ SocialWorkerはTwitter、Facebook、Line、Instagram、メールへの連携を�
 (2)Scriptから[SocialWorker.PostTwitter][SocialWorker.PostFacebook][SocialWorker.PostLine][SocialWorker.PostInstagram][SocialWorker.PostMail][SocialWorker.CreateChooser]を呼ぶ
 
 ■バージョン履歴
-▽1.0.0
-初期バージョン
+
+1.0.1
+- add : [Editor/SocialWorkerPostProcessBuild]追加。iOS9でカスタムURLスキームがinfo.plistに記載されていない場合にエラーになる問題の対応。
+
+1.0.0
+- 初期バージョン


### PR DESCRIPTION
iOS9でカスタムURLスキームがinfo.plistに記載されていない場合にエラーになる問題の対応。
